### PR TITLE
[interpreter] Simplify keyword lexing

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -19,7 +19,7 @@ WINMAKE =	winmake.bat
 
 DIRS =		util syntax binary text valid runtime exec script host main
 LIBS =		bigarray
-FLAGS = 	-cflags '-w +a-4-27-42-44-45 -warn-error +a'
+FLAGS = 	-cflags '-w +a-4-27-42-44-45 -warn-error +a-3'
 OCB =		ocamlbuild $(FLAGS) $(DIRS:%=-I %) $(LIBS:%=-libs %)
 JS =		# set to JS shell command to run JS tests
 

--- a/test/core/annotations.wast
+++ b/test/core/annotations.wast
@@ -1,4 +1,5 @@
 (@a)
+
 (@aas-3!@$d-@#4)
 (@@) (@$) (@+) (@0) (@.) (@!$@#$23414@#$)
 (@a x y z)
@@ -13,6 +14,9 @@
   ;; bla)
   ;; bla (@x
 )
+
+(assert_malformed (module quote "(@a Heiße Würstchen)") "illegal character")
+(assert_malformed (module quote "(@a )") "illegal character")
 
 (assert_malformed (module quote "( @a)") "unknown operator")
 


### PR DESCRIPTION
Multiply out all keywords and separate them into a pattern match. Makes lexer more accessible and allows accurate lexing of reserved words (which otherwise blew the lexer table).