### PR TITLE
[interpreter] add new assertions for custom sections

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -107,11 +107,19 @@ function assert_malformed(bytes) {
   throw new Error("Wasm decoding failure expected");
 }
 
+function assert_malformed_custom(bytes) {
+  return;
+}
+
 function assert_invalid(bytes) {
   try { module(bytes, false) } catch (e) {
     if (e instanceof WebAssembly.CompileError) return;
   }
   throw new Error("Wasm validation failure expected");
+}
+
+function assert_invalid_custom(bytes) {
+  return;
 }
 
 function assert_unlinkable(bytes) {
@@ -571,8 +579,12 @@ let of_assertion mods ass =
   match ass.it with
   | AssertMalformed (def, _) ->
     "assert_malformed(" ^ of_definition def ^ ");"
+  | AssertMalformedCustom (def, _) ->
+    "assert_malformed_custom(" ^ of_definition def ^ ");"
   | AssertInvalid (def, _) ->
     "assert_invalid(" ^ of_definition def ^ ");"
+  | AssertInvalidCustom (def, _) ->
+    "assert_invalid_custom(" ^ of_definition def ^ ");"
   | AssertUnlinkable (def, _) ->
     "assert_unlinkable(" ^ of_definition def ^ ");"
   | AssertUninstantiable (def, _) ->

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -458,7 +458,7 @@ let run_assertion ass =
     (match ignore (run_definition def) with
     | exception Custom.Syntax (_, msg) ->
       assert_message ass.at "annotation parsing" msg re
-    | _ -> Assert.error ass.at "expected decoding/parsing error"
+    | _ -> Assert.error ass.at "expected custom decoding/parsing error"
     )
 
   | AssertInvalid (def, re) ->

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -450,6 +450,12 @@ let run_assertion ass =
     (match ignore (run_definition def) with
     | exception Decode.Code (_, msg) -> assert_message ass.at "decoding" msg re
     | exception Parse.Syntax (_, msg) -> assert_message ass.at "parsing" msg re
+    | _ -> Assert.error ass.at "expected decoding/parsing error"
+    )
+
+  | AssertMalformedCustom (def, re) ->
+    trace "Asserting malformed custom...";
+    (match ignore (run_definition def) with
     | exception Custom.Syntax (_, msg) ->
       assert_message ass.at "annotation parsing" msg re
     | _ -> Assert.error ass.at "expected decoding/parsing error"
@@ -458,11 +464,20 @@ let run_assertion ass =
   | AssertInvalid (def, re) ->
     trace "Asserting invalid...";
     (match
-      let m, cs = run_definition def in
-      Valid.check_module_with_custom (m, cs)
+      let m, _ = run_definition def in
+      Valid.check_module m
     with
     | exception Valid.Invalid (_, msg) ->
       assert_message ass.at "validation" msg re
+    | _ -> Assert.error ass.at "expected validation error"
+    )
+
+  | AssertInvalidCustom (def, re) ->
+    trace "Asserting invalid custom...";
+    (match
+      let m, cs = run_definition def in
+      Valid.check_module_with_custom (m, cs)
+    with
     | exception Custom.Invalid (_, msg) ->
       assert_message ass.at "custom validation" msg re
     | _ -> Assert.error ass.at "expected validation error"

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -480,7 +480,7 @@ let run_assertion ass =
     with
     | exception Custom.Invalid (_, msg) ->
       assert_message ass.at "custom validation" msg re
-    | _ -> Assert.error ass.at "expected validation error"
+    | _ -> Assert.error ass.at "expected custom validation error"
     )
 
   | AssertUnlinkable (def, re) ->

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -464,8 +464,8 @@ let run_assertion ass =
   | AssertInvalid (def, re) ->
     trace "Asserting invalid...";
     (match
-      let m, _ = run_definition def in
-      Valid.check_module m
+      let m, cs = run_definition def in
+      Valid.check_module_with_custom (m, cs)
     with
     | exception Valid.Invalid (_, msg) ->
       assert_message ass.at "validation" msg re

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -40,7 +40,9 @@ and result' =
 type assertion = assertion' Source.phrase
 and assertion' =
   | AssertMalformed of definition * string
+  | AssertMalformedCustom of definition * string
   | AssertInvalid of definition * string
+  | AssertInvalidCustom of definition * string
   | AssertUnlinkable of definition * string
   | AssertUninstantiable of definition * string
   | AssertReturn of action * result list

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -758,8 +758,16 @@ let assertion mode ass =
     | _ ->
       [Node ("assert_malformed", [definition `Original None def; Atom (string re)])]
     )
+  | AssertMalformedCustom (def, re) ->
+    (match mode, def.it with
+    | `Binary, Quoted _ -> []
+    | _ ->
+      [Node ("assert_malformed_custom", [definition `Original None def; Atom (string re)])]
+    )
   | AssertInvalid (def, re) ->
     [Node ("assert_invalid", [definition mode None def; Atom (string re)])]
+  | AssertInvalidCustom (def, re) ->
+    [Node ("assert_invalid_custom", [definition mode None def; Atom (string re)])]
   | AssertUnlinkable (def, re) ->
     [Node ("assert_unlinkable", [definition mode None def; Atom (string re)])]
   | AssertUninstantiable (def, re) ->

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -680,6 +680,8 @@ rule token = parse
       | "get" -> GET
       | "assert_malformed" -> ASSERT_MALFORMED
       | "assert_invalid" -> ASSERT_INVALID
+      | "assert_malformed_custom" -> ASSERT_MALFORMED_CUSTOM
+      | "assert_invalid_custom" -> ASSERT_INVALID_CUSTOM
       | "assert_unlinkable" -> ASSERT_UNLINKABLE
       | "assert_return" -> ASSERT_RETURN
       | "assert_trap" -> ASSERT_TRAP

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -258,6 +258,7 @@ let parse_annots (m : module_) : Custom.section list =
 %token MODULE BIN QUOTE
 %token SCRIPT REGISTER INVOKE GET
 %token ASSERT_MALFORMED ASSERT_INVALID ASSERT_UNLINKABLE
+%token ASSERT_MALFORMED_CUSTOM ASSERT_INVALID_CUSTOM
 %token ASSERT_RETURN ASSERT_TRAP ASSERT_EXHAUSTION
 %token<Script.nan> NAN
 %token INPUT OUTPUT
@@ -1062,6 +1063,10 @@ assertion :
     { AssertMalformed (snd $3, $4) @@ at () }
   | LPAR ASSERT_INVALID script_module STRING RPAR
     { AssertInvalid (snd $3, $4) @@ at () }
+  | LPAR ASSERT_MALFORMED_CUSTOM script_module STRING RPAR
+    { AssertMalformedCustom (snd $3, $4) @@ at () }
+  | LPAR ASSERT_INVALID_CUSTOM script_module STRING RPAR
+    { AssertInvalidCustom (snd $3, $4) @@ at () }
   | LPAR ASSERT_UNLINKABLE script_module STRING RPAR
     { AssertUnlinkable (snd $3, $4) @@ at () }
   | LPAR ASSERT_TRAP script_module STRING RPAR

--- a/test/custom/custom/custom_annot.wast
+++ b/test/custom/custom/custom_annot.wast
@@ -22,22 +22,22 @@
 
 ;; Malformed name
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom)")
   "@custom annotation: missing section name"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom 4)")
   "@custom annotation: missing section name"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom bla)")
   "@custom annotation: missing section name"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom \"\\df\")")
   "@custom annotation: malformed UTF-8 encoding"
 )
@@ -45,32 +45,32 @@
 
 ;; Malformed placement 
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom \"bla\" here)")
   "@custom annotation: unexpected token"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom \"bla\" after)")
   "@custom annotation: unexpected token"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom \"bla\" (after))")
   "@custom annotation: malformed section kind"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom \"bla\" (type))")
   "@custom annotation: malformed placement"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom \"bla\" (aft type))")
   "@custom annotation: malformed placement"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(@custom \"bla\" (before types))")
   "@custom annotation: malformed section kind"
 )
@@ -78,22 +78,22 @@
 
 ;; Misplaced
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(type (@custom \"bla\") $t (func))")
   "misplaced @custom annotation"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(func (@custom \"bla\"))")
   "misplaced @custom annotation"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(func (block (@custom \"bla\")))")
   "misplaced @custom annotation"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(func (nop (@custom \"bla\")))")
   "misplaced @custom annotation"
 )

--- a/test/custom/name/name_annot.wast
+++ b/test/custom/name/name_annot.wast
@@ -4,17 +4,17 @@
 
 (module $moduel (@name "Modül"))
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(module (@name \"M1\") (@name \"M2\"))")
   "@name annotation: multiple module"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(module (func) (@name \"M\"))")
   "misplaced @name annotation"
 )
 
-(assert_malformed
+(assert_malformed_custom
   (module quote "(module (start $f (@name \"M\")) (func $f))")
   "misplaced @name annotation"
 )

--- a/test/harness/async_index.js
+++ b/test/harness/async_index.js
@@ -176,6 +176,12 @@ function assert_invalid(bytes) {
 
 const assert_malformed = assert_invalid;
 
+function assert_invalid_custom(bytes) {
+  module(bytes);
+}
+
+const assert_malformed_custom = assert_invalid_custom;
+
 function instance(bytes, imports, valid = true) {
   const test = valid
     ? "Test that WebAssembly instantiation succeeds"

--- a/test/harness/sync_index.js
+++ b/test/harness/sync_index.js
@@ -191,6 +191,18 @@ function assert_invalid(bytes) {
 
 const assert_malformed = assert_invalid;
 
+function assert_invalid_custom(bytes) {
+    uniqueTest(() => {
+        try {
+            module(bytes, /* valid */ true);
+        } catch(e) {
+            throw new Error('failed on custom section error');
+        }
+    }, "A wast module that should have an invalid or malformed custom section.");
+}
+
+const assert_malformed_custom = assert_invalid_custom;
+
 function instance(bytes, imports = registry, valid = true) {
     if (imports instanceof Result) {
         if (imports.isError())


### PR DESCRIPTION
assert_malformed and assert_invalid now have a _custom variant, for asserting custom section/annotation errors.

The js implementation is a no-op, since no JS engine currently support any kind of diagnostic for custom sections.


See https://github.com/WebAssembly/branch-hinting/issues/21 for more context