### PR TITLE
[interpreter] Fix custom section ordering

### DIFF
--- a/interpreter/custom/custom.ml
+++ b/interpreter/custom/custom.ml
@@ -11,9 +11,9 @@ type section_kind =
   | Export
   | Start
   | Elem
+  | DataCount
   | Code
   | Data
-  | DataCount
 
 type place =
   | Before of section_kind


### PR DESCRIPTION
I noticed that the name section was being placed before the code section, and the reason was the section comparison function.
The comparison is done based on the ordering of the  section_kind enum, which was incorrect.