### PR TITLE
Constrain custom section annotation placement

### DIFF
--- a/proposals/annotations/Overview.md
+++ b/proposals/annotations/Overview.md
@@ -66,6 +66,8 @@ Extend the Appendix on the Custom Sections:
   ```
   If placement relative to an explicit section is used, then that section must exist in the encoding of the annotated module.
 
+  Custom section annotations that appear within module fields rather than as siblings of module fields may be ignored.
+
   As with any matter concerning annotations, it is up to implementations how they handle the case where an explicit custom section overlaps with individual annotations that are associated with the same custom section.
 
 


### PR DESCRIPTION
The overview previously did not constrain the location of custom section annotations, implying that they should be allowed anywhere annotations in general are allowed, i.e. anywhere whitespace is allowed.

This flexibility is not necessary since the location of custom section annotations is not meaningful, and it also complicates parser implementations. To allow for simpler implementations that only check for custom section annotations in a single location, constrain the annotations to appear only at the top level of the module.